### PR TITLE
test(result): convenience and map methods

### DIFF
--- a/lib/core/option.ts
+++ b/lib/core/option.ts
@@ -588,7 +588,6 @@ export interface IOption<T> {
    * |  LHS: Some<T>  |    Some<T>   |     None    |
    * |  LHS:  None    |      None    |     None    |
    *
-   *
    * Can be used to perform synchronous side-effects which can derail the
    * current `Option<T>`
    *

--- a/lib/core/option.ts
+++ b/lib/core/option.ts
@@ -288,7 +288,7 @@ export interface IOption<T> {
    *
    * In case of `None`, this method short-circuits and returns `None`
    *
-   * This is equivalent to the canonical `flatMap()` method in traditional
+   * This is equivalent to the canonical `.flatMap()` method in traditional
    * functional idioms, thus it can be used to flatten instances of
    * `Option<Option<T>>` to `Option<T>`
    *
@@ -570,8 +570,15 @@ export interface IOption<T> {
   zip<U>(rhs: Option<U>): Option<[T, U]>;
 
   /**
-   * Use this to perform synchronous side-effects which can derail the
-   * current `Option<T>`
+   * Use this to conditionally pass-through the encapsulated value of
+   * type `<T>` based upon the outcome of the supplied `tripFn`
+   *
+   * In case of `None` this method short-circuits and returns `None`
+   *
+   * In case of `Some<T>`, the provided `tripFn` gets called with a value
+   * of type `<T>` and if the return value is:
+   *  - `Some<U>`: it is discarded and the original `Some<T>` is returned
+   *  - `None`: `None` is returned
    *
    * This is equivalent to chaining:
    * `original.andThen(tripFn).and(original)`
@@ -581,12 +588,9 @@ export interface IOption<T> {
    * |  LHS: Some<T>  |    Some<T>   |     None    |
    * |  LHS:  None    |      None    |     None    |
    *
-   * In case of `None` this method short-circuits and returns `None`
    *
-   * In case of `Some<T>`, the provided `tripFn` gets called with a value
-   * of type `<T>` and if the return value is:
-   *  - `Some<U>` - it is discarded and the original `Some<T>` is returned
-   *  - `None`: `None` is returned
+   * Can be used to perform synchronous side-effects which can derail the
+   * current `Option<T>`
    *
    * @category Option::Advanced
    *
@@ -836,7 +840,7 @@ export interface IOption<T> {
   tap(tapFn: (arg: Option<T>) => void): Option<T>;
 
   /**
-   * Use this to inspect the value inside an instace of `Some<T>`
+   * Use this to inspect the value inside an instance of `Some<T>`
    * in a transparent manner
    *
    * Short-curcuits in case of `None'

--- a/lib/core/option.ts
+++ b/lib/core/option.ts
@@ -90,7 +90,7 @@ export interface IOption<T> {
    * Canonical identity function
    *
    * Mainly useful for flattening types of `Option<Option<T>>` togehter
-   * with `andThen()`,
+   * with `.andThen()`,
    *
    * @category Option::Basic
    *

--- a/lib/core/result.ts
+++ b/lib/core/result.ts
@@ -83,9 +83,88 @@ export interface IResult<T, E> {
    */
   id(): Result<T, E>;
 
+  /**
+   * Use this to obtain a deep clone of `Result<T, E>`
+   *
+   * Under the hood, this uses the `structuredClone` algorithm exposed via
+   * the global function of the same name
+   *
+   * May incur performance penalties, depending on the platform, size and type
+   * of the data to be cloned
+   *
+   * Can be handy if user-defined operations on reference types mutate the
+   * passed value and the original value should be retained
+   *
+   * CAUTION: Mutations in a chained series of operations are strongly
+   * discouraged
+   *
+   * See the [reference](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone)
+   *
+   * @category Result::Basic
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * const record = { a: "thing" };
+   * const ok = Ok(record);
+   * const err = Err(record);
+   *
+   * const okClone = ok.clone();
+   * const errClone = err.clone();
+   *
+   * assert(okClone !== ok);
+   * assert(errClone !== err);
+   * assert(okClone.unwrap() !== record);
+   * assert(errClone.unwrap() !== record);
+   * ```
+   */
   clone(): Result<T, E>;
+
+  /**
+   * Use
+   *
+   * @category Result::
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * assert
+   * ```
+   */
   map<T2>(mapFn: (value: T) => T2): Result<T2, E>;
+
+  /**
+   * Use
+   *
+   * @category Result::
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * assert
+   * ```
+   */
   mapOr<T2>(mapFn: (value: T) => T2, orValue: T2): Ok<T2>;
+
+  /**
+   * Use
+   *
+   * @category Result::
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * assert
+   * ```
+   */
   mapOrElse<T2>(mapFn: (value: T) => T2, elseFn: (err: E) => T2): Ok<T2>;
   mapErr<E2>(mapFn: (err: E) => E2): Result<T, E2>;
   andThen<T2, E2>(

--- a/lib/core/result.ts
+++ b/lib/core/result.ts
@@ -60,7 +60,29 @@ export interface IResult<T, E> {
    * ```
    */
   isErr(): this is Err<E>;
+
+  /**
+   * Use this to return the Result itself.
+   *
+   * Canonical identity function. Mainly useful for flattening instances of
+   * `Result<Result<T, E>, E>` in combination with `.andThen()`
+   *
+   * @category Result::Basic
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * const res = Ok(Err(Error())) as Result<Result<number, Error>, TypeError>;
+   *
+   * const flattened: Result<number, Error> = res.andThen(res => res.id());
+   *
+   * assert(res.isErr() === true);
+   * ```
+   */
   id(): Result<T, E>;
+
   clone(): Result<T, E>;
   map<T2>(mapFn: (value: T) => T2): Result<T2, E>;
   mapOr<T2>(mapFn: (value: T) => T2, orValue: T2): Ok<T2>;

--- a/lib/core/result.ts
+++ b/lib/core/result.ts
@@ -123,56 +123,325 @@ export interface IResult<T, E> {
   clone(): Result<T, E>;
 
   /**
-   * Use
+   * Use this to map the encapsulated value `<T>' to `<T2>`.
    *
-   * @category Result::
+   * In case of `Err<E>` this method short-circuits. See {@linkcode IResult#mapErr}
+   * for the opposite case.
+   *
+   * @category Result::Basic
    *
    * @example
    * ```typescript
    * import { assert } from "./assert.ts";
    * import { Err, Ok, Result } from "./result.ts";
    *
-   * assert
+   * const double = (n: number) => n * 2;
+   * const ok = Ok(42);
+   * const err = Err(Error());
+   *
+   * const okRes = ok.map(double);
+   * const errRes = err.map(double);
+   *
+   * assert(okRes.isOk() === true);
+   * assert(okRes.unwrap() === 84);
+   * assert(errRes.isErr() === true);
+   * assert(errRes === err);
    * ```
    */
   map<T2>(mapFn: (value: T) => T2): Result<T2, E>;
 
   /**
-   * Use
+   * Same as `.map()` but in case of `Err<E>, a new instance 
+   * of `Ok`, wrapping the provided `orValue` will be returned.
    *
-   * @category Result::
+   * @category Result::Intermediate
    *
    * @example
    * ```typescript
    * import { assert } from "./assert.ts";
    * import { Err, Ok, Result } from "./result.ts";
    *
-   * assert
+   * const fallback = 10;
+   * const double = (n: number) => n * 2;
+   * const ok = Ok(5);
+   * const err = Err(Error());
+   *
+   * const mappedOk = ok.mapOr(double, fallback);
+   * const mappedErr = err.mapOr(double, fallback);
+   *
+   * assert(mappedOk.isOk() === true);
+   * assert(mappedOk.unwrap() === 10);
+   * assert(mappedErr.isErr() === false);
+   * assert(mappedErr.unwrap() === 10);
    * ```
    */
   mapOr<T2>(mapFn: (value: T) => T2, orValue: T2): Ok<T2>;
 
   /**
-   * Use
+   * Same as `.map()` but in case of `Err<E>, a new instance 
+   * of `Ok`, wrapping the return value of the provided `elseFn` will be returned.
    *
-   * @category Result::
+   * Use this if the fallback value is expensive to produce.
+   *
+   * @category Result::Intermediate
    *
    * @example
    * ```typescript
    * import { assert } from "./assert.ts";
    * import { Err, Ok, Result } from "./result.ts";
    *
-   * assert
+   * const fallback = (e: TypeError) => e.message.length;
+   * const double = (n: number) => n * 2;
+   * const ok = Ok(5);
+   * const err = Err(TypeError("Booom"));
+   *
+   * const mappedOk = ok.mapOrElse(double, fallback);
+   * const mappedErr = err.mapOrElse(double, fallback);
+   *
+   * assert(mappedOk.isOk() === true);
+   * assert(mappedOk.unwrap() === 10);
+   * assert(mappedErr.isErr() === false);
+   * assert(mappedErr.unwrap() === 5);
    * ```
    */
   mapOrElse<T2>(mapFn: (value: T) => T2, elseFn: (err: E) => T2): Ok<T2>;
+  
+  /**
+   * Use this to map the encapsulated value `<E>` to `<E2>`. In case of
+   * `Ok<T>`, this method short-circuits. See {@linkcode IResult#map}
+   * for the opposite case.
+   *
+   * @category Result::Basic
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * const toTypeError = (e: Error) => TypeError("Something went wrong", { cause: e });
+   * const ok = Ok(42);
+   * const err = Err(Error("This went wrong"));
+   *
+   * const mappedOk = ok.mapErr(toTypeError);
+   * const mappedErr = err.mapErr(toTypeError);
+   *
+   * assert(mappedOk.isOk() === true);
+   * assert(mappedOk === ok);
+   * assert(mappedErr.isErr() === true);
+   * assert(mappedErr !== err);
+   * assert(mappedErr.unwrap().cause === err.unwrap());
+   * ```
+   */
   mapErr<E2>(mapFn: (err: E) => E2): Result<T, E2>;
+
+  
+  /**
+   * Use this to produce a new instance of `Result<T2, E2>` from the 
+   * encapsulated value `<T>`. Can be used to flatten an instance of
+   * `Result<Result<T2, E2>, E>` to `Result<T2, E | E2>`.
+   *
+   * In case of `Err<E>`, this method short-circuits.
+   *
+   * See {@linkcode IResult#orElse} for the opposite case.
+   *
+   * Canonical `.flatMap()` or `.chain()` method.
+   *
+   * @category Result::Intermediate
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * const processString = function(str: string): Result<number, TypeError> {
+   *  if(str.length > 5) return Ok(str.length);
+   *  return Err(TypeError("String too short"));
+   * }
+   *
+   * const ok = Ok("Hello!");
+   * const err = Err(TypeError("Something went wrong"));
+   * const nested = Ok(Ok(42));
+   *
+   * const chained = ok.andThen(processString);
+   * const chainedErr = err.andThen(processString);
+   * const flattened = nested.andThen((r) => r.id());
+   *  
+   * assert(chained.isOk() === true);
+   * assert(chained.unwrap() === 6);
+   * assert(chainedErr.isErr() === true);
+   * assert(chainedErr === err);
+   * assert(flattened.isOk() === true);
+   * assert(flattened.unwrap() === 42);
+   * ```
+   */
   andThen<T2, E2>(
     thenFn: (value: T) => Result<T2, E2>,
   ): Err<E> | Result<T2, E2>;
+    
+  /**
+   * Use this to produce a new instance of `Result<T2, E2>` from the
+   * encapsulated value `<E>`. Can be used to flatten an instance of
+   * `Result<T, Result<T2, E2>>` to `Result<T | T2, E2>`.
+   *
+   * In case of `Ok<T>`, this method short-circuits.
+   *
+   * See {@linkcode IResult#andThen} for the opposite case.
+   *
+   * @category Result::Intermediate
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Option, Result } from "./mod.ts";
+   *
+   * function recover(e: Error): Result<string, Error> {
+   *   return Option(e.cause)
+   *     .filter((v): v is string => typeof v === "string")
+   *     .okOr(e);
+   * }
+   *
+   * const ok = Ok("ido!");
+   * const err = Err(Error("Panic!", { cause: "Fear" }));
+   * const nested = Err(Ok(42));
+   *
+   * const chained = ok.orElse(recover);
+   * const chainedErr = err.orElse(recover);
+   * const flattened = nested.orElse((r) => r.id());
+   *
+   * assert(chained.isOk() === true);
+   * assert(chained === ok);
+   * assert(chainedErr.isErr() === false);
+   * assert(chainedErr !== err);
+   * assert(flattened.isOk() === true);
+   * assert(flattened.unwrap() === 42);
+   * ```
+   */
   orElse<T2, E2>(elseFn: (err: E) => Result<T2, E2>): Ok<T> | Result<T2, E2>;
+
+  /**
+   * Use this to conditionally pass-through the encapsulated value `<T>`
+   * based upon the outcome of the supplied `tripFn`.
+   *
+   * In case of `Err<E>`, this method short-circuits.
+   *
+   * In case of `Ok<T>`, the supplied `tripFn` is called with the encapsulated
+   * value `<T>` and if the return value is:
+   *  - `Ok<T2>`: it is discarded and the original `Ok<T>` is returned
+   *  - `Err<E2>`: `Err<E2>` is returned
+   *
+   * See {@linkcode IResult#rise} for the opposite case.
+   *
+   * This is equivalent to chaining:
+   * `original.andThen(tripFn).and(original)`
+   *
+   * |**LHS `trip` RHS**|**RHS: Ok<T2>**|**RHS: Err<E2>**|
+   * |:----------------:|:-------------:|:--------------:|
+   * |  **LHS: Ok<T>**  |     Ok<T>     |     Err<E2>    |
+   * |  **LHS: Err<E>** |     Err<E>    |     Err<E>     |
+   *
+   * @category Result::Advanced
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Empty, Err, Ok, Result } from "./mod.ts";
+   * import { emptyDirSync } from "https://deno.land/std@0.207.0/fs/empty_dir.ts";
+   *
+   * const { BadResource, NotFound, PermissionDenied } = Deno.errors;
+   * type BadResource = typeof BadResource;
+   * type NotFound = typeof NotFound;
+   * type PermissionDenied = typeof PermissionDenied;
+   *
+   * const castTo = function<E>(e: unknown): E {
+   *   return e as E;
+   * }
+   *
+   * const getPath = function(): Result<string, NotFound> {
+   *   //perform a few checks...
+   *   return Ok(Deno.args[0]);
+   * }
+   *
+   * const prepareDir = Result.liftFallible(
+   *   emptyDirSync,
+   *   castTo<PermissionDenied>,
+   * ); 
+   *
+   * const writeBlobs = function(path: string): Result<Empty, BadResource> {
+   *   // create files and write something to them...
+   *   return Ok.empty();
+   * }
+   *
+   * const res = getPath()  // here we try get a path...
+   *   .trip(prepareDir)    // ...and if THIS works, we pass it on...
+   *   .andThen(writeBlobs) // ...so that we can process it here.
+   *   .inspect((_) => console.log("done"))
+   *   .inspectErr(console.error); 
+   *
+   * assert(res.unwrap() != null);
+   * ```
+   */
   trip<T2, E2>(tripFn: (value: T) => Result<T2, E2>): Result<T, E> | Err<E2>;
+
+  /**
+   * Use this to conditionally pass-through the encapsulated value `<E>`
+   * based upon the outcome of the supplied `riseFn`.
+   *
+   * In case of `Ok<T>`, this method short-circuits.
+   *
+   * In case of `Err<E>`, the supplied `riseFn` is called with the encapsulated
+   * value `<E>` and if the return value is:
+   *  - `Ok<T2>`: it is returned
+   *  - `Err<T2>`: it is discarded and the original `Err<E>` is returned
+   *
+   * See {@linkcode IResult#trip} for the opposite case.
+   *
+   * This is equivalent to chaining:
+   * `original.orElse(riseFn).or(original)`
+   *
+   * |**LHS `rise` RHS**|**RHS: Ok<T2>**|**RHS: Err<E2>**|
+   * |:----------------:|:-------------:|:--------------:|
+   * |  **LHS: Ok<T>**  |     Ok<T>     |     Ok<T>      |
+   * |  **LHS: Err<E>** |     Ok<T2>    |     Err<E>     |
+   *
+   * @category Result::Advanced
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * const { BadResource, NotFound, PermissionDenied } = Deno.errors;
+   * type BadResource = typeof BadResource;
+   * type NotFound = typeof NotFound;
+   * type PermissionDenied = typeof PermissionDenied;
+   *
+   * type Config = Record<string, string>;
+   *
+   * const readConfig = function(): Result<Config, NotFound> {
+   *   // Oh boy, that didn't work out...
+   *   return Err(NotFound("Config not found"));
+   * }
+   *
+   * const readFallbackConfig = function(): Result<Config, PermissionDenied> {
+   *   // ...also doesn't work
+   *   return Err(PermissionDenied());
+   * }
+   *
+   * const doSomething = function(cfg: Config): Result<string, BadResource> {
+   *   // do some processing here...
+   *   return Ok(JSON.stringify(cfg));
+   * }
+   *   
+   * const res = readConfig()      // Let's try to read the config...
+   *   .rise(readFallbackConfig)   // ...try the fallback...
+   *   .andThen(doSomething)       // ...but we retain the original error
+   *   .inspect(console.log)       // Ok<string>
+   *   .inspectErr(console.error); // Err<NotFound> | Err<BadResource>
+   *
+   * assert(res.isErr() === true);
+   */
   rise<T2, E2>(riseFn: (err: E) => Result<T2, E2>): Result<T, E> | Ok<T2>;
+
   and<T2, E2>(rhs: Result<T2, E2>): Err<E> | Result<T2, E2>;
   or<T2, E2>(rhs: Result<T2, E2>): Ok<T> | Result<T2, E2>;
   zip<T2, E2>(rhs: Result<T2, E2>): Ok<[T, T2]> | Err<E> | Err<E2>;
@@ -513,8 +782,7 @@ class _Ok<T> implements IResult<T, never> {
     return Ok([this.#value, rhs.unwrap()]);
   }
   trip<T2, E2>(thenFn: (value: T) => Result<T2, E2>): Ok<T> | Err<E2> {
-    const clone = this.clone().unwrap();
-    const lhs = thenFn(clone);
+    const lhs = thenFn(this.#value);
 
     return lhs.and(this);
   }
@@ -627,8 +895,7 @@ class _Err<E> implements IResult<never, E> {
     return this;
   }
   rise<T2, E2>(riseFn: (err: E) => Result<T2, E2>): Ok<T2> | Err<E> {
-    const clone = this.clone().unwrap();
-    const lhs = riseFn(clone);
+    const lhs = riseFn(this.#err);
 
     return lhs.or(this);
   }

--- a/lib/core/result.ts
+++ b/lib/core/result.ts
@@ -151,7 +151,7 @@ export interface IResult<T, E> {
   map<T2>(mapFn: (value: T) => T2): Result<T2, E>;
 
   /**
-   * Same as `.map()` but in case of `Err<E>, a new instance 
+   * Same as `.map()` but in case of `Err<E>, a new instance
    * of `Ok`, wrapping the provided `orValue` will be returned.
    *
    * @category Result::Intermediate
@@ -178,7 +178,7 @@ export interface IResult<T, E> {
   mapOr<T2>(mapFn: (value: T) => T2, orValue: T2): Ok<T2>;
 
   /**
-   * Same as `.map()` but in case of `Err<E>, a new instance 
+   * Same as `.map()` but in case of `Err<E>, a new instance
    * of `Ok`, wrapping the return value of the provided `elseFn` will be returned.
    *
    * Use this if the fallback value is expensive to produce.
@@ -205,7 +205,7 @@ export interface IResult<T, E> {
    * ```
    */
   mapOrElse<T2>(mapFn: (value: T) => T2, elseFn: (err: E) => T2): Ok<T2>;
-  
+
   /**
    * Use this to map the encapsulated value `<E>` to `<E2>`. In case of
    * `Ok<T>`, this method short-circuits. See {@linkcode IResult#map}
@@ -234,9 +234,8 @@ export interface IResult<T, E> {
    */
   mapErr<E2>(mapFn: (err: E) => E2): Result<T, E2>;
 
-  
   /**
-   * Use this to produce a new instance of `Result<T2, E2>` from the 
+   * Use this to produce a new instance of `Result<T2, E2>` from the
    * encapsulated value `<T>`. Can be used to flatten an instance of
    * `Result<Result<T2, E2>, E>` to `Result<T2, E | E2>`.
    *
@@ -265,7 +264,7 @@ export interface IResult<T, E> {
    * const chained = ok.andThen(processString);
    * const chainedErr = err.andThen(processString);
    * const flattened = nested.andThen((r) => r.id());
-   *  
+   *
    * assert(chained.isOk() === true);
    * assert(chained.unwrap() === 6);
    * assert(chainedErr.isErr() === true);
@@ -277,7 +276,7 @@ export interface IResult<T, E> {
   andThen<T2, E2>(
     thenFn: (value: T) => Result<T2, E2>,
   ): Err<E> | Result<T2, E2>;
-    
+
   /**
    * Use this to produce a new instance of `Result<T2, E2>` from the
    * encapsulated value `<E>`. Can be used to flatten an instance of
@@ -364,7 +363,7 @@ export interface IResult<T, E> {
    * const prepareDir = Result.liftFallible(
    *   emptyDirSync,
    *   castTo<PermissionDenied>,
-   * ); 
+   * );
    *
    * const writeBlobs = function(path: string): Result<Empty, BadResource> {
    *   // create files and write something to them...
@@ -375,7 +374,7 @@ export interface IResult<T, E> {
    *   .trip(prepareDir)    // ...and if THIS works, we pass it on...
    *   .andThen(writeBlobs) // ...so that we can process it here.
    *   .inspect((_) => console.log("done"))
-   *   .inspectErr(console.error); 
+   *   .inspectErr(console.error);
    *
    * assert(res.unwrap() != null);
    * ```
@@ -431,7 +430,7 @@ export interface IResult<T, E> {
    *   // do some processing here...
    *   return Ok(JSON.stringify(cfg));
    * }
-   *   
+   *
    * const res = readConfig()      // Let's try to read the config...
    *   .rise(readFallbackConfig)   // ...try the fallback...
    *   .andThen(doSomething)       // ...but we retain the original error
@@ -521,7 +520,7 @@ export interface IResult<T, E> {
    * const record = { a: "thing" };
    * const ok = Ok(record);
    * let ref: Record<string, string> = {};
-   * 
+   *
    * const res = ok.tap((res) => {
    *   ref = res.unwrap();
    *   ref.a = "fling";

--- a/lib/core/result.ts
+++ b/lib/core/result.ts
@@ -251,8 +251,8 @@ export interface IResult<T, E> {
    *
    * const record = { a: "thing" };
    * const ok = Ok(record);
-   *
    * let ref: Record<string, string> = {};
+   * 
    * const res = ok.tap((res) => {
    *   ref = res.unwrap();
    *   ref.a = "fling";
@@ -264,7 +264,61 @@ export interface IResult<T, E> {
    * ```
    */
   tap(tapFn: (res: Result<T, E>) => void): Result<T, E>;
+
+  /**
+   * Use this to inspect the the encapsulated value `<T>` transparently.
+   *
+   * Mainly used for debugging and logging purposes.
+   *
+   * In case of `Err<E>`, this method short-cuits and returns the `Err<E>`
+   * instance. See {@linkcode IResult#inspectErr} for the opposite case;
+   *
+   * @category Result::Basic
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * const record = { a: "thing" };
+   * const ok = Ok(record);
+   * const err = Err(record);
+   *
+   * const okRes = ok.inspect(console.log);   // logs '{ a: "thing" }'
+   * const errRes = err.inspect(console.log); // not called
+   *
+   * assert(okRes === ok);
+   * assert(errRes === err);
+   * ```
+   */
   inspect(inspectFn: (value: T) => void): Result<T, E>;
+
+  /**
+   * Use this to inspect the the encapsulated value `<E>` transparently.
+   *
+   * Mainly used for debugging and logging purposes.
+   *
+   * In case of `Ok<T>`, this method short-cuits and returns the `Ok<T>`
+   * instance. See {@linkcode IResult#inspect} for the opposite case;
+   *
+   * @category Result::Basic
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * const record = { a: "thing" };
+   * const ok = Ok(record);
+   * const err = Err(record);
+   *
+   * const okRes = ok.inspectErr(console.log);   // not called
+   * const errRes = err.inspectErr(console.log); // logs '{ a: "thing" }'
+   *
+   * assert(okRes === ok);
+   * assert(errRes === err);
+   * ```
+   */
   inspectErr(inspectFn: (err: E) => void): Result<T, E>;
 
   /**

--- a/lib/core/result.ts
+++ b/lib/core/result.ts
@@ -230,6 +230,39 @@ export interface IResult<T, E> {
    * ```
    */
   iter(): IterableIterator<T>;
+
+  /**
+   * Use this to perform side-effects transparently.
+   *
+   * The `tapFn` receives a deep clone of `Result<T, E>` {@linkcode IResult#clone}
+   *
+   * This may have performance implications, dependending on the size of
+   * the wrapped value `<T | E>`, but ensures that the `tapFn` can never
+   * change or invalidate the state of the `Result<T, E>` instance
+   *
+   * See the [reference](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone)
+   *
+   * @category Result::Intermediate
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * const record = { a: "thing" };
+   * const ok = Ok(record);
+   *
+   * let ref: Record<string, string> = {};
+   * const res = ok.tap((res) => {
+   *   ref = res.unwrap();
+   *   ref.a = "fling";
+   * });
+   *
+   * assert(res === ok);
+   * assert(ref !== record);
+   * assert(ref.a !== record.a);
+   * ```
+   */
   tap(tapFn: (res: Result<T, E>) => void): Result<T, E>;
   inspect(inspectFn: (value: T) => void): Result<T, E>;
   inspectErr(inspectFn: (err: E) => void): Result<T, E>;

--- a/lib/core/result.ts
+++ b/lib/core/result.ts
@@ -17,7 +17,48 @@ import { None, Option } from "./option.ts";
  * Base interface implemented by `Ok<T>` and `Err<E>`
  */
 export interface IResult<T, E> {
+  /**
+   * Type predicate - use this to narrow `Result<T, E>` to `Ok<T>`
+   *
+   * @category Result::Basic
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * const res = Ok(42) as Result<number, Error>;
+   *
+   * if (res.isOk()) {
+   *   // Here we have access to the `Ok` variant
+   *   const n: number = res.unwrap();
+   * }
+   *
+   * assert(res.isOk() === true);
+   * ```
+   */
   isOk(): this is Ok<T>;
+
+  /**
+   * Type predicate - use this to narrow `Result<T, E>` to `Err<E>`
+   *
+   * @category Result::Basic
+   *
+   * @example
+   * ```typescript
+   * import { assert } from "./assert.ts";
+   * import { Err, Ok, Result } from "./result.ts";
+   *
+   * const res = Err(Error()) as Result<number, Error>;
+   *
+   * if (res.isErr()) {
+   *   // Here we have access to the `Err` variant
+   *   const e: Error = res.unwrap();
+   * }
+   *
+   * assert(res.isErr() === true);
+   * ```
+   */
   isErr(): this is Err<E>;
   id(): Result<T, E>;
   clone(): Result<T, E>;

--- a/lib/core/result_test.ts
+++ b/lib/core/result_test.ts
@@ -1,11 +1,13 @@
 import {
   assertEquals,
+  assertInstanceOf,
   assertNotStrictEquals,
   assertStrictEquals,
   assertThrows,
   assertType,
 } from "../../dev_deps.ts";
 import type { IsExact } from "../../dev_deps.ts";
+import { Empty } from "./mod.ts";
 import { Err, Ok, Result, Results } from "./result.ts";
 import type {
   InferredErrTuple,
@@ -323,6 +325,142 @@ Deno.test("eitherway::Result::Ok", async (t) => {
     })
   });
 
+  await t.step("Ok<T> -> Map Methods", async (t) => {
+    await t.step(".map() -> returns new instance of Ok with applied mapFn", () => {
+      const toNumber = (str: string) => str.length;
+      const ok = Ok("thing") as Result<string, Error>;
+
+      const res = ok.map(toNumber);
+
+      assertType<IsExact<typeof res, Result<number, Error>>>(true);
+      assertStrictEquals(res.isOk(), true);
+      assertStrictEquals(res.unwrap(), 5);
+    });
+
+    await t.step(".mapOr() -> returns new instance of Ok with applied mapFn", () => {
+      const fallback = 10;
+      const toNumber = (str: string) => str.length;
+      const ok = Ok("thing") as Result<string, Error>;
+
+      const res = ok.mapOr(toNumber, fallback);
+
+      assertType<IsExact<typeof res, Ok<number>>>(true);
+      assertStrictEquals(res.isOk(), true);
+      assertStrictEquals(res.unwrap(), 5);
+    });
+
+    await t.step(".mapOrElse() -> returns new instance of Ok with applied mapFn", () => {
+      const fallback = () => 10;
+      const toNumber = (str: string) => str.length;
+      const ok = Ok("thing") as Result<string, Error>;
+
+      const res = ok.mapOrElse(toNumber, fallback);
+
+      assertType<IsExact<typeof res, Ok<number>>>(true);
+      assertStrictEquals(res.isOk(), true);
+      assertStrictEquals(res.unwrap(), 5);
+    });
+
+    await t.step(".mapErr() -> short-circuits and returns immediately", () => {
+      const toTypeError = (e: Error) => TypeError("Something went wrong", { cause: e });
+      const ok = Ok(42) as Result<number, Error>;
+
+      const mapped = ok.mapErr(toTypeError);
+
+      assertType<IsExact<typeof mapped, Result<number, TypeError>>>(true);
+      assertStrictEquals(mapped, ok);
+      assertStrictEquals(mapped.isOk(), true);
+      assertStrictEquals(mapped.unwrap(), 42);
+    });
+
+    await t.step(".andThen() -> returns new instance of Result with supplied thenFn", () => {
+      const processString = function(str: string): Result<number, TypeError> {
+        if (str.length > 5) return Ok(str.length);
+        return Err(TypeError("String too short"));
+      }
+      const ok = Ok("thing!") as Result<string, Error>;
+
+      const chained = ok.andThen(processString);
+
+      assertType<IsExact<typeof chained, Result<number, TypeError | Error>>>(true);
+      assertStrictEquals(chained.isOk(), true);
+      assertStrictEquals(chained.unwrap(), 6);
+    });
+
+    await t.step(".andThen() -> flattens nested Result instance", () => {
+      const nested = Ok(Ok(42)) as Result<Result<number, TypeError>, Error>;
+
+      const flattened = nested.andThen((res) => res);
+
+      assertType<IsExact<typeof flattened, Result<number, TypeError | Error>>>(true);
+      assertStrictEquals(flattened.isOk(), true);
+      assertStrictEquals(flattened.unwrap(), 42);
+    });
+
+    await t.step(".orElse() -> short-circuits and returns immediately", () => {
+      const recover = function(e: Error): Result<string, never> {
+        const recovered = e.cause as string ?? "xDefaultx";
+        return Ok(recovered);
+      }
+
+      const ok = Ok("thing") as Result<string, Error>;
+
+      const chained = ok.orElse(recover);
+
+      assertType<IsExact<typeof chained, Result<string, never>>>(true);
+      assertStrictEquals(chained, ok);
+      assertStrictEquals(chained.isOk(), true);
+      assertStrictEquals(chained.unwrap(), "thing");
+    });
+
+    await t.step(".trip() -> returns a new Err instance upon failure of tripFn", () => {
+      const checkIfEven = function(n: number): Result<Empty, TypeError> {
+        if (n % 2 === 0) return Ok.empty();
+        return Err(TypeError());
+      }
+
+      const ok = Ok(41) as Result<number, Error>;
+
+      const tripped = ok.trip(checkIfEven);
+
+      assertType<IsExact<typeof tripped, Result<number, Error | TypeError>>>(true);
+      assertStrictEquals(tripped.isErr(), true);
+      assertInstanceOf(tripped.unwrap(), TypeError);
+    });
+
+    await t.step(".trip() -> retains original Ok instance upon success of tripFn", () => {
+      const checkIfEven = function(n: number): Result<Empty, TypeError> {
+        if (n % 2 === 0) return Ok.empty();
+        return Err(TypeError());
+      }
+
+      const ok = Ok(42) as Result<number, Error>;
+
+      const tripped = ok.trip(checkIfEven);
+
+      assertType<IsExact<typeof tripped, Result<number, Error | TypeError>>>(true);
+      assertStrictEquals(tripped, ok);
+      assertStrictEquals(tripped.isOk(), true);
+      assertStrictEquals(tripped.unwrap(), 42);
+    });
+
+    await t.step(".rise() -> short-circuits and returns immediately", () => {
+      const recover = function(e: Error): Result<string, TypeError> {
+        const recovered = e.cause as string ?? "xDefaultx";
+        return Ok(recovered);
+      }
+
+      const ok = Ok("thing") as Result<string, Error>;
+
+      const risen = ok.rise(recover);
+
+      assertType<IsExact<typeof risen, Result<string, Error | TypeError>>>(true);
+      assertStrictEquals(risen, ok);
+      assertStrictEquals(risen.isOk(), true);
+      assertStrictEquals(risen.unwrap(), "thing");
+    });
+  });
+
   await t.step("Ok<T> -> Convenience Methods", async (t) => {
     await t.step(".id() -> returns the instance itself", () => {
       const res = Ok(42);
@@ -470,6 +608,137 @@ Deno.test("eitherway::Result::Err", async (t) => {
       } 
 
       assertStrictEquals(res.isErr(), true);
+    });
+  });
+
+  await t.step("Err<E> -> Map Methods", async (t) => {
+    await t.step(".map() -> short-circuits and returns immediately", () => {
+      const double = (n: number) => n * 2;
+      const err = Err("thing") as Result<number, string>;
+
+      const mapped = err.map(double);
+
+      assertType<IsExact<typeof mapped, Result<number, string>>>(true);
+      assertStrictEquals(mapped, err);
+      assertStrictEquals(mapped.isErr(), true);
+      assertStrictEquals(mapped.unwrap(), "thing");
+    });
+
+    await t.step(".mapOr() -> returns new instance of Ok with supplied orValue", () => {
+      const fallback = 10;
+      const toNumber = (str: string) => str.length;
+      const err = Err(Error()) as Result<string, Error>;
+
+      const mapped = err.mapOr(toNumber, fallback);
+
+      assertType<IsExact<typeof mapped, Ok<number>>>(true);
+      assertStrictEquals(mapped.isOk(), true);
+      assertStrictEquals(mapped.unwrap(), 10);
+    });
+
+    await t.step(".mapOrElse() -> returns new instance of Ok with return value of elseFn", () => {
+      const fallback = () => 10;
+      const toNumber = (str: string) => str.length;
+      const err = Err(Error());
+
+      const mapped = err.mapOrElse(toNumber, fallback);
+
+      assertType<IsExact<typeof mapped, Ok<number>>>(true);
+      assertStrictEquals(mapped.isOk(), true);
+      assertStrictEquals(mapped.unwrap(), 10);
+    });
+
+    await t.step(".mapErr() -> returns new instance of Err with the supplied mapFn", () => {
+      const toTypeError = (e: Error) => TypeError("Something went wrong", { cause: e });
+      const err = Err(Error()) as Result<number, Error>;
+
+      const mapped = err.mapErr(toTypeError);
+
+      assertType<IsExact<typeof mapped, Result<number, TypeError>>>(true);
+      assertStrictEquals(mapped.isErr(), true);
+      assertNotStrictEquals(mapped, err);
+    });
+
+    await t.step(".andThen() -> short-circuits and returns immediately", () => {
+      const processString = function(str: string): Result<number, TypeError> {
+        if (str.length > 5) return Ok(str.length);
+        return Err(TypeError("String too short"));
+      }
+
+      const err = Err(Error()) as Result<string, Error>;
+
+      const chained = err.andThen(processString);
+
+      assertType<IsExact<typeof chained, Result<number, Error | TypeError>>>(true);
+      assertStrictEquals(chained, err);
+    });
+
+    await t.step(".orElse() -> returns new instance of Result with the supplied elseFn", () => {
+      const recover = function(e: Error): Result<string, never> {
+        const recovered = e.cause as string ?? "xDefaultx";
+        return Ok(recovered);
+      }
+
+      const err = Err(Error()) as Result<string, Error>;
+
+      const chained = err.orElse(recover);
+
+      assertType<IsExact<typeof chained, Result<string, never>>>(true);
+      assertNotStrictEquals(chained, err);
+      assertStrictEquals(chained.isOk(), true);
+    });
+
+    await t.step(".orElse() -> flattens nested Result instance", () => {
+      const nested = Err(Err(Error())) as Result<string, Result<number, Error>>;
+
+      const flattened = nested.orElse((res) => res); 
+
+      assertType<IsExact<typeof flattened, Ok<string> | Result<number, Error>>>(true);
+      assertStrictEquals(flattened.isErr(), true);
+    });
+
+    await t.step(".trip() -> short-circuits and returns immediately", () => {
+      let count = 0;
+      const noop = function(): Result<Empty, TypeError> {
+        count += 1;
+        return Ok.empty();
+      }
+
+      const err = Err(Error()) as Result<string, Error>;
+
+      const tripped = err.trip(noop);
+
+      assertType<IsExact<typeof tripped, Result<string, Error | TypeError>>>(true);
+      assertStrictEquals(count, 0);
+      assertStrictEquals(tripped, err);
+    });
+
+    await t.step(".rise() -> returns the new Ok instance upon success of riseFn", () => {
+      const recover = function(e: Error): Result<string, TypeError> {
+        const recovered = e.cause as string ?? "xDefaultx";
+        return Ok(recovered);
+      }
+
+      const err = Err(Error()) as Result<number, Error>;
+
+      const risen = err.rise(recover);
+
+      assertType<IsExact<typeof risen, Ok<string> | Result<number, Error>>>(true);
+      assertStrictEquals(risen.isOk(), true);
+    });
+
+    await t.step("rise() -> passes on the original Err variant if riseFn fails", () => {
+      const recover = function(_: Error): Result<string, TypeError> {
+        return Err(TypeError());
+      }
+
+      const err = Err(Error()) as Result<number, Error>;
+
+      const risen = err.rise(recover);
+
+      assertType<IsExact<typeof risen, Ok<string> | Result<number, Error>>>(true);
+      assertStrictEquals(risen.isErr(), true);
+      assertStrictEquals(risen, err);
     });
   });
 

--- a/lib/core/result_test.ts
+++ b/lib/core/result_test.ts
@@ -309,60 +309,70 @@ Deno.test("eitherway::Result::Ok", async (t) => {
 
       if (res.isOk()) {
         assertType<IsExact<typeof res, Ok<number>>>(true);
-      } 
+      }
 
       assertStrictEquals(res.isOk(), true);
-    })
+    });
 
     await t.step(".isErr() -> narrows to Err by returning false", () => {
       const res = Ok(42) as Result<number, TypeError>;
 
       if (res.isErr()) {
         assertType<IsExact<typeof res, Err<TypeError>>>(true);
-      } 
+      }
 
       assertStrictEquals(res.isErr(), false);
-    })
+    });
   });
 
   await t.step("Ok<T> -> Map Methods", async (t) => {
-    await t.step(".map() -> returns new instance of Ok with applied mapFn", () => {
-      const toNumber = (str: string) => str.length;
-      const ok = Ok("thing") as Result<string, Error>;
+    await t.step(
+      ".map() -> returns new instance of Ok with applied mapFn",
+      () => {
+        const toNumber = (str: string) => str.length;
+        const ok = Ok("thing") as Result<string, Error>;
 
-      const res = ok.map(toNumber);
+        const res = ok.map(toNumber);
 
-      assertType<IsExact<typeof res, Result<number, Error>>>(true);
-      assertStrictEquals(res.isOk(), true);
-      assertStrictEquals(res.unwrap(), 5);
-    });
+        assertType<IsExact<typeof res, Result<number, Error>>>(true);
+        assertStrictEquals(res.isOk(), true);
+        assertStrictEquals(res.unwrap(), 5);
+      },
+    );
 
-    await t.step(".mapOr() -> returns new instance of Ok with applied mapFn", () => {
-      const fallback = 10;
-      const toNumber = (str: string) => str.length;
-      const ok = Ok("thing") as Result<string, Error>;
+    await t.step(
+      ".mapOr() -> returns new instance of Ok with applied mapFn",
+      () => {
+        const fallback = 10;
+        const toNumber = (str: string) => str.length;
+        const ok = Ok("thing") as Result<string, Error>;
 
-      const res = ok.mapOr(toNumber, fallback);
+        const res = ok.mapOr(toNumber, fallback);
 
-      assertType<IsExact<typeof res, Ok<number>>>(true);
-      assertStrictEquals(res.isOk(), true);
-      assertStrictEquals(res.unwrap(), 5);
-    });
+        assertType<IsExact<typeof res, Ok<number>>>(true);
+        assertStrictEquals(res.isOk(), true);
+        assertStrictEquals(res.unwrap(), 5);
+      },
+    );
 
-    await t.step(".mapOrElse() -> returns new instance of Ok with applied mapFn", () => {
-      const fallback = () => 10;
-      const toNumber = (str: string) => str.length;
-      const ok = Ok("thing") as Result<string, Error>;
+    await t.step(
+      ".mapOrElse() -> returns new instance of Ok with applied mapFn",
+      () => {
+        const fallback = () => 10;
+        const toNumber = (str: string) => str.length;
+        const ok = Ok("thing") as Result<string, Error>;
 
-      const res = ok.mapOrElse(toNumber, fallback);
+        const res = ok.mapOrElse(toNumber, fallback);
 
-      assertType<IsExact<typeof res, Ok<number>>>(true);
-      assertStrictEquals(res.isOk(), true);
-      assertStrictEquals(res.unwrap(), 5);
-    });
+        assertType<IsExact<typeof res, Ok<number>>>(true);
+        assertStrictEquals(res.isOk(), true);
+        assertStrictEquals(res.unwrap(), 5);
+      },
+    );
 
     await t.step(".mapErr() -> short-circuits and returns immediately", () => {
-      const toTypeError = (e: Error) => TypeError("Something went wrong", { cause: e });
+      const toTypeError = (e: Error) =>
+        TypeError("Something went wrong", { cause: e });
       const ok = Ok(42) as Result<number, Error>;
 
       const mapped = ok.mapErr(toTypeError);
@@ -373,35 +383,44 @@ Deno.test("eitherway::Result::Ok", async (t) => {
       assertStrictEquals(mapped.unwrap(), 42);
     });
 
-    await t.step(".andThen() -> returns new instance of Result with supplied thenFn", () => {
-      const processString = function(str: string): Result<number, TypeError> {
-        if (str.length > 5) return Ok(str.length);
-        return Err(TypeError("String too short"));
-      }
-      const ok = Ok("thing!") as Result<string, Error>;
+    await t.step(
+      ".andThen() -> returns new instance of Result with supplied thenFn",
+      () => {
+        const processString = function (
+          str: string,
+        ): Result<number, TypeError> {
+          if (str.length > 5) return Ok(str.length);
+          return Err(TypeError("String too short"));
+        };
+        const ok = Ok("thing!") as Result<string, Error>;
 
-      const chained = ok.andThen(processString);
+        const chained = ok.andThen(processString);
 
-      assertType<IsExact<typeof chained, Result<number, TypeError | Error>>>(true);
-      assertStrictEquals(chained.isOk(), true);
-      assertStrictEquals(chained.unwrap(), 6);
-    });
+        assertType<IsExact<typeof chained, Result<number, TypeError | Error>>>(
+          true,
+        );
+        assertStrictEquals(chained.isOk(), true);
+        assertStrictEquals(chained.unwrap(), 6);
+      },
+    );
 
     await t.step(".andThen() -> flattens nested Result instance", () => {
       const nested = Ok(Ok(42)) as Result<Result<number, TypeError>, Error>;
 
       const flattened = nested.andThen((res) => res);
 
-      assertType<IsExact<typeof flattened, Result<number, TypeError | Error>>>(true);
+      assertType<IsExact<typeof flattened, Result<number, TypeError | Error>>>(
+        true,
+      );
       assertStrictEquals(flattened.isOk(), true);
       assertStrictEquals(flattened.unwrap(), 42);
     });
 
     await t.step(".orElse() -> short-circuits and returns immediately", () => {
-      const recover = function(e: Error): Result<string, never> {
+      const recover = function (e: Error): Result<string, never> {
         const recovered = e.cause as string ?? "xDefaultx";
         return Ok(recovered);
-      }
+      };
 
       const ok = Ok("thing") as Result<string, Error>;
 
@@ -413,48 +432,60 @@ Deno.test("eitherway::Result::Ok", async (t) => {
       assertStrictEquals(chained.unwrap(), "thing");
     });
 
-    await t.step(".trip() -> returns a new Err instance upon failure of tripFn", () => {
-      const checkIfEven = function(n: number): Result<Empty, TypeError> {
-        if (n % 2 === 0) return Ok.empty();
-        return Err(TypeError());
-      }
+    await t.step(
+      ".trip() -> returns a new Err instance upon failure of tripFn",
+      () => {
+        const checkIfEven = function (n: number): Result<Empty, TypeError> {
+          if (n % 2 === 0) return Ok.empty();
+          return Err(TypeError());
+        };
 
-      const ok = Ok(41) as Result<number, Error>;
+        const ok = Ok(41) as Result<number, Error>;
 
-      const tripped = ok.trip(checkIfEven);
+        const tripped = ok.trip(checkIfEven);
 
-      assertType<IsExact<typeof tripped, Result<number, Error | TypeError>>>(true);
-      assertStrictEquals(tripped.isErr(), true);
-      assertInstanceOf(tripped.unwrap(), TypeError);
-    });
+        assertType<IsExact<typeof tripped, Result<number, Error | TypeError>>>(
+          true,
+        );
+        assertStrictEquals(tripped.isErr(), true);
+        assertInstanceOf(tripped.unwrap(), TypeError);
+      },
+    );
 
-    await t.step(".trip() -> retains original Ok instance upon success of tripFn", () => {
-      const checkIfEven = function(n: number): Result<Empty, TypeError> {
-        if (n % 2 === 0) return Ok.empty();
-        return Err(TypeError());
-      }
+    await t.step(
+      ".trip() -> retains original Ok instance upon success of tripFn",
+      () => {
+        const checkIfEven = function (n: number): Result<Empty, TypeError> {
+          if (n % 2 === 0) return Ok.empty();
+          return Err(TypeError());
+        };
 
-      const ok = Ok(42) as Result<number, Error>;
+        const ok = Ok(42) as Result<number, Error>;
 
-      const tripped = ok.trip(checkIfEven);
+        const tripped = ok.trip(checkIfEven);
 
-      assertType<IsExact<typeof tripped, Result<number, Error | TypeError>>>(true);
-      assertStrictEquals(tripped, ok);
-      assertStrictEquals(tripped.isOk(), true);
-      assertStrictEquals(tripped.unwrap(), 42);
-    });
+        assertType<IsExact<typeof tripped, Result<number, Error | TypeError>>>(
+          true,
+        );
+        assertStrictEquals(tripped, ok);
+        assertStrictEquals(tripped.isOk(), true);
+        assertStrictEquals(tripped.unwrap(), 42);
+      },
+    );
 
     await t.step(".rise() -> short-circuits and returns immediately", () => {
-      const recover = function(e: Error): Result<string, TypeError> {
+      const recover = function (e: Error): Result<string, TypeError> {
         const recovered = e.cause as string ?? "xDefaultx";
         return Ok(recovered);
-      }
+      };
 
       const ok = Ok("thing") as Result<string, Error>;
 
       const risen = ok.rise(recover);
 
-      assertType<IsExact<typeof risen, Result<string, Error | TypeError>>>(true);
+      assertType<IsExact<typeof risen, Result<string, Error | TypeError>>>(
+        true,
+      );
       assertStrictEquals(risen, ok);
       assertStrictEquals(risen.isOk(), true);
       assertStrictEquals(risen.unwrap(), "thing");
@@ -470,67 +501,81 @@ Deno.test("eitherway::Result::Ok", async (t) => {
       assertStrictEquals(ref, res);
     });
 
-    await t.step(".clone() -> returns a new instance with a deep copy of the encapsulated value", () => {
-      const record = { a: "thing" };
-      const ok = Ok(record);
+    await t.step(
+      ".clone() -> returns a new instance with a deep copy of the encapsulated value",
+      () => {
+        const record = { a: "thing" };
+        const ok = Ok(record);
 
-      const clone = ok.clone();
+        const clone = ok.clone();
 
-      assertNotStrictEquals(clone, ok);
-      assertNotStrictEquals(clone.unwrap(), record);
-    });
+        assertNotStrictEquals(clone, ok);
+        assertNotStrictEquals(clone.unwrap(), record);
+      },
+    );
 
-    await t.step(".tap() -> calls tapFn with a deep copy of the encapsulated value", () => {
-      /**
-       * HOF to capture changes to the original value
-       */
-      const createTapFn = function<T>(
-        originalValue: T,
-        originalResult: Ok<T>,
-      ): (res: Result<T, unknown>) => void {
-        return (res: Result<T, unknown>) => {
-          assertNotStrictEquals(originalValue, res.unwrap());
-          assertNotStrictEquals(originalResult, res);
-          assertEquals(originalValue, res.unwrap());
+    await t.step(
+      ".tap() -> calls tapFn with a deep copy of the encapsulated value",
+      () => {
+        /**
+         * HOF to capture changes to the original value
+         */
+        const createTapFn = function <T>(
+          originalValue: T,
+          originalResult: Ok<T>,
+        ): (res: Result<T, unknown>) => void {
+          return (res: Result<T, unknown>) => {
+            assertNotStrictEquals(originalValue, res.unwrap());
+            assertNotStrictEquals(originalResult, res);
+            assertEquals(originalValue, res.unwrap());
+          };
         };
-      };
 
-      const record = { a: "thing" };
-      const ok = Ok(record);
-      const tapAssertion = createTapFn(record, ok);
+        const record = { a: "thing" };
+        const ok = Ok(record);
+        const tapAssertion = createTapFn(record, ok);
 
-      const res = ok.tap(tapAssertion);
+        const res = ok.tap(tapAssertion);
 
-      assertStrictEquals(res, ok);
-    });
+        assertStrictEquals(res, ok);
+      },
+    );
 
-    await t.step(".inspect() -> calls the provided inspectFn with the encapsulated value", () => {
-      const createInspectFn = function<T>(originalValue: T): (value: T) => void {
-        return (value: T) => {
-          assertStrictEquals(value, originalValue);
+    await t.step(
+      ".inspect() -> calls the provided inspectFn with the encapsulated value",
+      () => {
+        const createInspectFn = function <T>(
+          originalValue: T,
+        ): (value: T) => void {
+          return (value: T) => {
+            assertStrictEquals(value, originalValue);
+          };
         };
-      };
-      const record = { a: "thing" };
-      const ok = Ok(record);
-      const inspectAssertion = createInspectFn(record);
+        const record = { a: "thing" };
+        const ok = Ok(record);
+        const inspectAssertion = createInspectFn(record);
 
-      const res = ok.inspectErr(inspectAssertion);
+        const res = ok.inspectErr(inspectAssertion);
 
-      assertStrictEquals(res, ok);
-    });
+        assertStrictEquals(res, ok);
+      },
+    );
 
-    await t.step(".inspectErr() -> short-circuits and returns immediately", () => {
-      let count = 0;
-      const inspectFn = () => {
-        count += 1;
-      }
-      const ok = Ok(1);
+    await t.step(
+      ".inspectErr() -> short-circuits and returns immediately",
+      () => {
+        let count = 0;
+        const inspectFn = () => {
+          count += 1;
+        };
+        const ok = Ok(1);
 
-      const res = ok.inspectErr(inspectFn);
+        const res = ok.inspectErr(inspectFn);
 
-      assertStrictEquals(res, ok);
-      assertStrictEquals(count, 0);
-    });
+        assertStrictEquals(res, ok);
+        assertStrictEquals(count, 0);
+      },
+    );
   });
 
   await t.step("Ok<T> -> JS well-known Symbols and Methods", async (t) => {
@@ -595,17 +640,17 @@ Deno.test("eitherway::Result::Err", async (t) => {
 
       if (res.isOk()) {
         assertType<IsExact<typeof res, Ok<number>>>(true);
-      } 
+      }
 
       assertStrictEquals(res.isOk(), false);
-    })
+    });
 
     await t.step(".isErr() -> narrows to Err by returning true", () => {
       const res = Err(TypeError()) as Result<number, TypeError>;
 
       if (res.isErr()) {
         assertType<IsExact<typeof res, Err<TypeError>>>(true);
-      } 
+      }
 
       assertStrictEquals(res.isErr(), true);
     });
@@ -624,122 +669,151 @@ Deno.test("eitherway::Result::Err", async (t) => {
       assertStrictEquals(mapped.unwrap(), "thing");
     });
 
-    await t.step(".mapOr() -> returns new instance of Ok with supplied orValue", () => {
-      const fallback = 10;
-      const toNumber = (str: string) => str.length;
-      const err = Err(Error()) as Result<string, Error>;
+    await t.step(
+      ".mapOr() -> returns new instance of Ok with supplied orValue",
+      () => {
+        const fallback = 10;
+        const toNumber = (str: string) => str.length;
+        const err = Err(Error()) as Result<string, Error>;
 
-      const mapped = err.mapOr(toNumber, fallback);
+        const mapped = err.mapOr(toNumber, fallback);
 
-      assertType<IsExact<typeof mapped, Ok<number>>>(true);
-      assertStrictEquals(mapped.isOk(), true);
-      assertStrictEquals(mapped.unwrap(), 10);
-    });
+        assertType<IsExact<typeof mapped, Ok<number>>>(true);
+        assertStrictEquals(mapped.isOk(), true);
+        assertStrictEquals(mapped.unwrap(), 10);
+      },
+    );
 
-    await t.step(".mapOrElse() -> returns new instance of Ok with return value of elseFn", () => {
-      const fallback = () => 10;
-      const toNumber = (str: string) => str.length;
-      const err = Err(Error());
+    await t.step(
+      ".mapOrElse() -> returns new instance of Ok with return value of elseFn",
+      () => {
+        const fallback = () => 10;
+        const toNumber = (str: string) => str.length;
+        const err = Err(Error());
 
-      const mapped = err.mapOrElse(toNumber, fallback);
+        const mapped = err.mapOrElse(toNumber, fallback);
 
-      assertType<IsExact<typeof mapped, Ok<number>>>(true);
-      assertStrictEquals(mapped.isOk(), true);
-      assertStrictEquals(mapped.unwrap(), 10);
-    });
+        assertType<IsExact<typeof mapped, Ok<number>>>(true);
+        assertStrictEquals(mapped.isOk(), true);
+        assertStrictEquals(mapped.unwrap(), 10);
+      },
+    );
 
-    await t.step(".mapErr() -> returns new instance of Err with the supplied mapFn", () => {
-      const toTypeError = (e: Error) => TypeError("Something went wrong", { cause: e });
-      const err = Err(Error()) as Result<number, Error>;
+    await t.step(
+      ".mapErr() -> returns new instance of Err with the supplied mapFn",
+      () => {
+        const toTypeError = (e: Error) =>
+          TypeError("Something went wrong", { cause: e });
+        const err = Err(Error()) as Result<number, Error>;
 
-      const mapped = err.mapErr(toTypeError);
+        const mapped = err.mapErr(toTypeError);
 
-      assertType<IsExact<typeof mapped, Result<number, TypeError>>>(true);
-      assertStrictEquals(mapped.isErr(), true);
-      assertNotStrictEquals(mapped, err);
-    });
+        assertType<IsExact<typeof mapped, Result<number, TypeError>>>(true);
+        assertStrictEquals(mapped.isErr(), true);
+        assertNotStrictEquals(mapped, err);
+      },
+    );
 
     await t.step(".andThen() -> short-circuits and returns immediately", () => {
-      const processString = function(str: string): Result<number, TypeError> {
+      const processString = function (str: string): Result<number, TypeError> {
         if (str.length > 5) return Ok(str.length);
         return Err(TypeError("String too short"));
-      }
+      };
 
       const err = Err(Error()) as Result<string, Error>;
 
       const chained = err.andThen(processString);
 
-      assertType<IsExact<typeof chained, Result<number, Error | TypeError>>>(true);
+      assertType<IsExact<typeof chained, Result<number, Error | TypeError>>>(
+        true,
+      );
       assertStrictEquals(chained, err);
     });
 
-    await t.step(".orElse() -> returns new instance of Result with the supplied elseFn", () => {
-      const recover = function(e: Error): Result<string, never> {
-        const recovered = e.cause as string ?? "xDefaultx";
-        return Ok(recovered);
-      }
+    await t.step(
+      ".orElse() -> returns new instance of Result with the supplied elseFn",
+      () => {
+        const recover = function (e: Error): Result<string, never> {
+          const recovered = e.cause as string ?? "xDefaultx";
+          return Ok(recovered);
+        };
 
-      const err = Err(Error()) as Result<string, Error>;
+        const err = Err(Error()) as Result<string, Error>;
 
-      const chained = err.orElse(recover);
+        const chained = err.orElse(recover);
 
-      assertType<IsExact<typeof chained, Result<string, never>>>(true);
-      assertNotStrictEquals(chained, err);
-      assertStrictEquals(chained.isOk(), true);
-    });
+        assertType<IsExact<typeof chained, Result<string, never>>>(true);
+        assertNotStrictEquals(chained, err);
+        assertStrictEquals(chained.isOk(), true);
+      },
+    );
 
     await t.step(".orElse() -> flattens nested Result instance", () => {
       const nested = Err(Err(Error())) as Result<string, Result<number, Error>>;
 
-      const flattened = nested.orElse((res) => res); 
+      const flattened = nested.orElse((res) => res);
 
-      assertType<IsExact<typeof flattened, Ok<string> | Result<number, Error>>>(true);
+      assertType<IsExact<typeof flattened, Ok<string> | Result<number, Error>>>(
+        true,
+      );
       assertStrictEquals(flattened.isErr(), true);
     });
 
     await t.step(".trip() -> short-circuits and returns immediately", () => {
       let count = 0;
-      const noop = function(): Result<Empty, TypeError> {
+      const noop = function (): Result<Empty, TypeError> {
         count += 1;
         return Ok.empty();
-      }
+      };
 
       const err = Err(Error()) as Result<string, Error>;
 
       const tripped = err.trip(noop);
 
-      assertType<IsExact<typeof tripped, Result<string, Error | TypeError>>>(true);
+      assertType<IsExact<typeof tripped, Result<string, Error | TypeError>>>(
+        true,
+      );
       assertStrictEquals(count, 0);
       assertStrictEquals(tripped, err);
     });
 
-    await t.step(".rise() -> returns the new Ok instance upon success of riseFn", () => {
-      const recover = function(e: Error): Result<string, TypeError> {
-        const recovered = e.cause as string ?? "xDefaultx";
-        return Ok(recovered);
-      }
+    await t.step(
+      ".rise() -> returns the new Ok instance upon success of riseFn",
+      () => {
+        const recover = function (e: Error): Result<string, TypeError> {
+          const recovered = e.cause as string ?? "xDefaultx";
+          return Ok(recovered);
+        };
 
-      const err = Err(Error()) as Result<number, Error>;
+        const err = Err(Error()) as Result<number, Error>;
 
-      const risen = err.rise(recover);
+        const risen = err.rise(recover);
 
-      assertType<IsExact<typeof risen, Ok<string> | Result<number, Error>>>(true);
-      assertStrictEquals(risen.isOk(), true);
-    });
+        assertType<IsExact<typeof risen, Ok<string> | Result<number, Error>>>(
+          true,
+        );
+        assertStrictEquals(risen.isOk(), true);
+      },
+    );
 
-    await t.step("rise() -> passes on the original Err variant if riseFn fails", () => {
-      const recover = function(_: Error): Result<string, TypeError> {
-        return Err(TypeError());
-      }
+    await t.step(
+      "rise() -> passes on the original Err variant if riseFn fails",
+      () => {
+        const recover = function (_: Error): Result<string, TypeError> {
+          return Err(TypeError());
+        };
 
-      const err = Err(Error()) as Result<number, Error>;
+        const err = Err(Error()) as Result<number, Error>;
 
-      const risen = err.rise(recover);
+        const risen = err.rise(recover);
 
-      assertType<IsExact<typeof risen, Ok<string> | Result<number, Error>>>(true);
-      assertStrictEquals(risen.isErr(), true);
-      assertStrictEquals(risen, err);
-    });
+        assertType<IsExact<typeof risen, Ok<string> | Result<number, Error>>>(
+          true,
+        );
+        assertStrictEquals(risen.isErr(), true);
+        assertStrictEquals(risen, err);
+      },
+    );
   });
 
   await t.step("Err<E> -> Convenience Methods", async (t) => {
@@ -752,45 +826,51 @@ Deno.test("eitherway::Result::Err", async (t) => {
       assertStrictEquals(ref, res);
     });
 
-    await t.step(".clone(), -> returns a new instance with a deep copy of the encapsulated value", () => {
-      const record = { a: "thing" };
-      const err = Err(record);
+    await t.step(
+      ".clone(), -> returns a new instance with a deep copy of the encapsulated value",
+      () => {
+        const record = { a: "thing" };
+        const err = Err(record);
 
-      const clone = err.clone();
+        const clone = err.clone();
 
-      assertNotStrictEquals(clone, err);
-      assertNotStrictEquals(clone.unwrap(), record);
-    });
+        assertNotStrictEquals(clone, err);
+        assertNotStrictEquals(clone.unwrap(), record);
+      },
+    );
 
-    await t.step(".tap() -> calls the tapFn with a deep clone of the encapsulated value", () => {
-      /**
-       * HOF to capture changes to the original value
-       */
-      const createTapFn = function<E>(
-        originalValue: E,
-        originalResult: Err<E>,
-      ): (res: Result<unknown, E>) => void {
-        return (res: Result<unknown, E>) => {
-          assertNotStrictEquals(originalValue, res.unwrap());
-          assertNotStrictEquals(originalResult, res);
-          assertEquals(originalValue, res.unwrap());
+    await t.step(
+      ".tap() -> calls the tapFn with a deep clone of the encapsulated value",
+      () => {
+        /**
+         * HOF to capture changes to the original value
+         */
+        const createTapFn = function <E>(
+          originalValue: E,
+          originalResult: Err<E>,
+        ): (res: Result<unknown, E>) => void {
+          return (res: Result<unknown, E>) => {
+            assertNotStrictEquals(originalValue, res.unwrap());
+            assertNotStrictEquals(originalResult, res);
+            assertEquals(originalValue, res.unwrap());
+          };
         };
-      };
 
-      const record = { a: "thing" };
-      const err = Err(record);
-      const tapAssertion = createTapFn(record, err);
+        const record = { a: "thing" };
+        const err = Err(record);
+        const tapAssertion = createTapFn(record, err);
 
-      const res = err.tap(tapAssertion);
+        const res = err.tap(tapAssertion);
 
-      assertStrictEquals(res, err);
-    });
+        assertStrictEquals(res, err);
+      },
+    );
 
     await t.step(".inspect() -> short-circuits and returns immediately", () => {
       let count = 0;
       const inspectFn = () => {
         count += 1;
-      }
+      };
       const err = Err(1);
 
       const res = err.inspect(inspectFn);
@@ -799,20 +879,25 @@ Deno.test("eitherway::Result::Err", async (t) => {
       assertStrictEquals(count, 0);
     });
 
-    await t.step(".inspectErr() -> calls the provided inspectFn with the encapsulated value", () => {
-      const createInspectFn = function<E>(originalValue: E): (value: E) => void {
-        return (value: E) => {
-          assertStrictEquals(value, originalValue);
+    await t.step(
+      ".inspectErr() -> calls the provided inspectFn with the encapsulated value",
+      () => {
+        const createInspectFn = function <E>(
+          originalValue: E,
+        ): (value: E) => void {
+          return (value: E) => {
+            assertStrictEquals(value, originalValue);
+          };
         };
-      };
-      const record = { a: "thing" };
-      const err = Err(record);
-      const inspectAssertion = createInspectFn(record);
+        const record = { a: "thing" };
+        const err = Err(record);
+        const inspectAssertion = createInspectFn(record);
 
-      const res = err.inspectErr(inspectAssertion);
+        const res = err.inspectErr(inspectAssertion);
 
-      assertStrictEquals(res, err);
-    });
+        assertStrictEquals(res, err);
+      },
+    );
   });
 
   await t.step("Err<E> -> JS well-known Symbols and Methods", async (t) => {

--- a/lib/core/result_test.ts
+++ b/lib/core/result_test.ts
@@ -341,6 +341,30 @@ Deno.test("eitherway::Result::Ok", async (t) => {
       assertNotStrictEquals(clone, ok);
       assertNotStrictEquals(clone.unwrap(), record);
     });
+
+    await t.step(".tap() -> calls tapFn with a deep copy of the encapsulated value", () => {
+      /**
+       * HOF to capture changes to the original value
+       */
+      const createTapFn = function<T>(
+        originalValue: T,
+        originalResult: Ok<T>,
+      ): (res: Result<T, unknown>) => void {
+        return (res: Result<T, unknown>) => {
+          assertNotStrictEquals(originalValue, res.unwrap());
+          assertNotStrictEquals(originalResult, res);
+          assertEquals(originalValue, res.unwrap());
+        };
+      };
+
+      const record = { a: "thing" };
+      const ok = Ok(record);
+      const tapAssertion = createTapFn(record, ok);
+
+      const res = ok.tap(tapAssertion);
+
+      assertStrictEquals(res, ok);
+    });
   });
 
   await t.step("Ok<T> -> JS well-known Symbols and Methods", async (t) => {
@@ -439,6 +463,30 @@ Deno.test("eitherway::Result::Err", async (t) => {
 
       assertNotStrictEquals(clone, err);
       assertNotStrictEquals(clone.unwrap(), record);
+    });
+
+    await t.step(".tap() -> calls the tapFn with a deep clone of the encapsulated value", () => {
+      /**
+       * HOF to capture changes to the original value
+       */
+      const createTapFn = function<E>(
+        originalValue: E,
+        originalResult: Err<E>,
+      ): (res: Result<unknown, E>) => void {
+        return (res: Result<unknown, E>) => {
+          assertNotStrictEquals(originalValue, res.unwrap());
+          assertNotStrictEquals(originalResult, res);
+          assertEquals(originalValue, res.unwrap());
+        };
+      };
+
+      const record = { a: "thing" };
+      const err = Err(record);
+      const tapAssertion = createTapFn(record, err);
+
+      const res = err.tap(tapAssertion);
+
+      assertStrictEquals(res, err);
     });
   });
 

--- a/lib/core/result_test.ts
+++ b/lib/core/result_test.ts
@@ -1,5 +1,6 @@
 import {
   assertEquals,
+  assertNotStrictEquals,
   assertStrictEquals,
   assertThrows,
   assertType,
@@ -330,6 +331,16 @@ Deno.test("eitherway::Result::Ok", async (t) => {
 
       assertStrictEquals(ref, res);
     });
+
+    await t.step(".clone() -> returns a new instance with a deep copy of the encapsulated value", () => {
+      const record = { a: "thing" };
+      const ok = Ok(record);
+
+      const clone = ok.clone();
+
+      assertNotStrictEquals(clone, ok);
+      assertNotStrictEquals(clone.unwrap(), record);
+    });
   });
 
   await t.step("Ok<T> -> JS well-known Symbols and Methods", async (t) => {
@@ -418,6 +429,16 @@ Deno.test("eitherway::Result::Err", async (t) => {
 
       assertType<IsExact<typeof ref, typeof res>>(true);
       assertStrictEquals(ref, res);
+    });
+
+    await t.step(".clone(), -> returns a new instance with a deep copy of the encapsulated value", () => {
+      const record = { a: "thing" };
+      const err = Err(record);
+
+      const clone = err.clone();
+
+      assertNotStrictEquals(clone, err);
+      assertNotStrictEquals(clone.unwrap(), record);
     });
   });
 

--- a/lib/core/result_test.ts
+++ b/lib/core/result_test.ts
@@ -300,7 +300,7 @@ Deno.test("eitherway::Results", async (t) => {
 });
 
 Deno.test("eitherway::Result::Ok", async (t) => {
-  await t.step("Ok<T> -> Type predicates", async (t) => {
+  await t.step("Ok<T> -> Type Predicates", async (t) => {
     await t.step(".isOk() -> narrows to Ok by returning true", () => {
       const res = Ok(42) as Result<number, TypeError>;
 
@@ -320,7 +320,16 @@ Deno.test("eitherway::Result::Ok", async (t) => {
 
       assertStrictEquals(res.isErr(), false);
     })
-      
+  });
+
+  await t.step("Ok<T> -> Convenience Methods", async (t) => {
+    await t.step(".id() -> returns the instance itself", () => {
+      const res = Ok(42);
+
+      const ref = res.id();
+
+      assertStrictEquals(ref, res);
+    });
   });
 
   await t.step("Ok<T> -> JS well-known Symbols and Methods", async (t) => {
@@ -379,8 +388,8 @@ Deno.test("eitherway::Result::Ok", async (t) => {
 });
 
 Deno.test("eitherway::Result::Err", async (t) => {
-  await t.step("Err<E> -> Type predicates", async (t) => {
-    await t.step(".isOk() -> narrows to Err by returning false", () => {
+  await t.step("Err<E> -> Type Predicates", async (t) => {
+    await t.step(".isOk() -> narrows to Ok by returning false", () => {
       const res = Err(TypeError()) as Result<number, TypeError>;
 
       if (res.isOk()) {
@@ -398,6 +407,17 @@ Deno.test("eitherway::Result::Err", async (t) => {
       } 
 
       assertStrictEquals(res.isErr(), true);
+    });
+  });
+
+  await t.step("Err<E> -> Convenience Methods", async (t) => {
+    await t.step(".id() -> returns the instance itself", () => {
+      const res = Err(1);
+
+      const ref = res.id();
+
+      assertType<IsExact<typeof ref, typeof res>>(true);
+      assertStrictEquals(ref, res);
     });
   });
 

--- a/lib/core/result_test.ts
+++ b/lib/core/result_test.ts
@@ -300,6 +300,29 @@ Deno.test("eitherway::Results", async (t) => {
 });
 
 Deno.test("eitherway::Result::Ok", async (t) => {
+  await t.step("Ok<T> -> Type predicates", async (t) => {
+    await t.step(".isOk() -> narrows to Ok by returning true", () => {
+      const res = Ok(42) as Result<number, TypeError>;
+
+      if (res.isOk()) {
+        assertType<IsExact<typeof res, Ok<number>>>(true);
+      } 
+
+      assertStrictEquals(res.isOk(), true);
+    })
+
+    await t.step(".isErr() -> narrows to Err by returning false", () => {
+      const res = Ok(42) as Result<number, TypeError>;
+
+      if (res.isErr()) {
+        assertType<IsExact<typeof res, Err<TypeError>>>(true);
+      } 
+
+      assertStrictEquals(res.isErr(), false);
+    })
+      
+  });
+
   await t.step("Ok<T> -> JS well-known Symbols and Methods", async (t) => {
     await t.step(".toString() -> returns the string tag", () => {
       const okTag = Ok("thing").toString();
@@ -356,6 +379,28 @@ Deno.test("eitherway::Result::Ok", async (t) => {
 });
 
 Deno.test("eitherway::Result::Err", async (t) => {
+  await t.step("Err<E> -> Type predicates", async (t) => {
+    await t.step(".isOk() -> narrows to Err by returning false", () => {
+      const res = Err(TypeError()) as Result<number, TypeError>;
+
+      if (res.isOk()) {
+        assertType<IsExact<typeof res, Ok<number>>>(true);
+      } 
+
+      assertStrictEquals(res.isOk(), false);
+    })
+
+    await t.step(".isErr() -> narrows to Err by returning true", () => {
+      const res = Err(TypeError()) as Result<number, TypeError>;
+
+      if (res.isErr()) {
+        assertType<IsExact<typeof res, Err<TypeError>>>(true);
+      } 
+
+      assertStrictEquals(res.isErr(), true);
+    });
+  });
+
   await t.step("Err<E> -> JS well-known Symbols and Methods", async (t) => {
     await t.step(".toString() -> returns the string tag", () => {
       const errTag = Err(Error()).toString();

--- a/lib/core/result_test.ts
+++ b/lib/core/result_test.ts
@@ -365,6 +365,34 @@ Deno.test("eitherway::Result::Ok", async (t) => {
 
       assertStrictEquals(res, ok);
     });
+
+    await t.step(".inspect() -> calls the provided inspectFn with the encapsulated value", () => {
+      const createInspectFn = function<T>(originalValue: T): (value: T) => void {
+        return (value: T) => {
+          assertStrictEquals(value, originalValue);
+        };
+      };
+      const record = { a: "thing" };
+      const ok = Ok(record);
+      const inspectAssertion = createInspectFn(record);
+
+      const res = ok.inspectErr(inspectAssertion);
+
+      assertStrictEquals(res, ok);
+    });
+
+    await t.step(".inspectErr() -> short-circuits and returns immediately", () => {
+      let count = 0;
+      const inspectFn = () => {
+        count += 1;
+      }
+      const ok = Ok(1);
+
+      const res = ok.inspectErr(inspectFn);
+
+      assertStrictEquals(res, ok);
+      assertStrictEquals(count, 0);
+    });
   });
 
   await t.step("Ok<T> -> JS well-known Symbols and Methods", async (t) => {
@@ -485,6 +513,34 @@ Deno.test("eitherway::Result::Err", async (t) => {
       const tapAssertion = createTapFn(record, err);
 
       const res = err.tap(tapAssertion);
+
+      assertStrictEquals(res, err);
+    });
+
+    await t.step(".inspect() -> short-circuits and returns immediately", () => {
+      let count = 0;
+      const inspectFn = () => {
+        count += 1;
+      }
+      const err = Err(1);
+
+      const res = err.inspect(inspectFn);
+
+      assertStrictEquals(res, err);
+      assertStrictEquals(count, 0);
+    });
+
+    await t.step(".inspectErr() -> calls the provided inspectFn with the encapsulated value", () => {
+      const createInspectFn = function<E>(originalValue: E): (value: E) => void {
+        return (value: E) => {
+          assertStrictEquals(value, originalValue);
+        };
+      };
+      const record = { a: "thing" };
+      const err = Err(record);
+      const inspectAssertion = createInspectFn(record);
+
+      const res = err.inspectErr(inspectAssertion);
 
       assertStrictEquals(res, err);
     });


### PR DESCRIPTION
- test(result): type predicates
- test(result): id method and inline docs
- test(result): clone method and inline docs
- rest(result): tap method and inline docs
- test(result): inspect methods and inline docs
- chore(option): fixed format in inline docs
- test(result): map methods and inline docs
- chore(core): fmt'ed changes
