### PR TITLE
perf/task construction

### DIFF
--- a/bench/async_composition_bench.ts
+++ b/bench/async_composition_bench.ts
@@ -4,11 +4,15 @@ import { Task } from "../lib/async/task.ts";
 import * as TaskOps from "../lib/async/operators.ts";
 
 const INPUTS = [
+  "casio",
   undefined,
-  "fortytwo",
   "lenghtySuperLenghtyGibberishString",
   "",
   "5",
+  undefined,
+  "houseknifes",
+  undefined,
+  "doordashed",
 ];
 
 Deno.bench({
@@ -108,7 +112,7 @@ namespace TaskFlows {
   function toUpperCase(input: string | undefined): Task<string, TypeError> {
     return Option(input)
       .okOrElse(() => TypeError("Input is undefined"))
-      .into((res) => Task.of(res))
+      .into(Task.of<string, TypeError>)
       .map(async (str) => {
         await sleep(1);
         return str.toUpperCase();
@@ -118,7 +122,7 @@ namespace TaskFlows {
   function stringToLength(input: string): Task<number, TypeError> {
     return Option.fromCoercible(input)
       .okOrElse(() => TypeError("Input string is empty"))
-      .into((res) => Task.of(res))
+      .into(Task.of<string, TypeError>)
       .map(async (str) => {
         await sleep(1);
         return str.length;
@@ -128,7 +132,7 @@ namespace TaskFlows {
   function powerOfSelf(input: number): Task<number, TypeError> {
     return Option.fromCoercible(input)
       .okOrElse(() => TypeError("Input is not a valid number"))
-      .into((res) => Task.of(res))
+      .into(Task.of<number, TypeError>)
       .andThen(async (n) => {
         await sleep(1);
         return Option.fromCoercible(Math.pow(n, n))

--- a/bench/async_propagation_bench.ts
+++ b/bench/async_propagation_bench.ts
@@ -1,6 +1,10 @@
 //deno-lint-ignore-file
 import { Task } from "../lib/async/mod.ts";
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 Deno.bench({
   name: "Async Exception Propagation",
   group: "Async::Propagation",
@@ -23,10 +27,12 @@ Deno.bench({
 
 export namespace AsyncExceptions {
   async function fail() {
+    await sleep(1);
     throw TypeError("Fail!");
   }
   async function propagate() {
     try {
+      await sleep(1);
       return await fail();
     } catch (e) {
       throw e;
@@ -34,6 +40,7 @@ export namespace AsyncExceptions {
   }
   export async function rethrow() {
     try {
+      await sleep(1);
       return await propagate();
     } catch (e) {
       throw e;
@@ -42,13 +49,16 @@ export namespace AsyncExceptions {
 }
 
 export namespace TaskErrors {
-  function fail() {
+  async function fail() {
+    await sleep(1);
     return Task.fail(TypeError("Fail!"));
   }
   async function propagate() {
+    await sleep(1);
     return await fail();
   }
   export async function linearReturn() {
+    await sleep(1);
     return await propagate();
   }
 }

--- a/bench/micro_bench.ts
+++ b/bench/micro_bench.ts
@@ -1,5 +1,5 @@
 //deno-lint-ignore-file
-import { Err, Ok, Result, asInfallible } from "../lib/core/result.ts";
+import { asInfallible, Err, Ok, Result } from "../lib/core/result.ts";
 import { Task } from "../lib/async/task.ts";
 import { Option } from "../lib/core/option.ts";
 

--- a/bench/micro_bench.ts
+++ b/bench/micro_bench.ts
@@ -1,43 +1,112 @@
 //deno-lint-ignore-file
+import { Err, Ok, Result, asInfallible } from "../lib/core/result.ts";
 import { Task } from "../lib/async/task.ts";
-import { Err, Ok } from "../lib/core/result.ts";
 import { Option } from "../lib/core/option.ts";
+
+const ERR = Err("foo");
+const OK = Ok("foo");
+
+async function produceRes(): Promise<Result<string, never>> {
+  return Ok("foo");
+}
+
+async function produceValue(): Promise<string> {
+  return "foo";
+}
 
 Deno.bench({
   name: "Promise.resolve(Ok)",
-  group: "Micro::Async::Instantiation",
+  group: "Micro::Async::Construction",
   fn: () => {
-    const res = Promise.resolve(Ok("foo"));
+    const res = Promise.resolve(OK);
+  },
+});
+
+Deno.bench({
+  name: "new Promise(Ok)",
+  group: "Micro::Async::Construction",
+  baseline: true,
+  fn: () => {
+    const res = new Promise((resolve) => resolve(OK));
   },
 });
 
 Deno.bench({
   name: "Task.succeed",
-  group: "Micro::Async::Instantiation",
+  group: "Micro::Async::Construction",
   fn: () => {
     const res = Task.succeed("foo");
   },
 });
 
 Deno.bench({
-  name: "Promise.resolve(Err)",
-  group: "Micro::Async::Instantiation",
+  name: "Task.of(Ok)",
+  group: "Micro::Async::Construction",
   fn: () => {
-    const res = Promise.resolve(Err(Error("foo")));
+    const res = Task.of(OK);
+  },
+});
+
+Deno.bench({
+  name: "Promise.resolve(Err)",
+  group: "Micro::Async::Construction",
+  fn: () => {
+    const res = Promise.resolve(ERR);
+  },
+});
+
+Deno.bench({
+  name: "new Promise(Err)",
+  group: "Micro::Async::Construction",
+  baseline: true,
+  fn: () => {
+    const res = new Promise((resolve) => resolve(ERR));
   },
 });
 
 Deno.bench({
   name: "Task.fail",
-  group: "Micro::Async::Instantiation",
+  group: "Micro::Async::Construction",
   fn: () => {
-    const res = Task.fail(Error("foo"));
+    const res = Task.fail("foo");
+  },
+});
+
+Deno.bench({
+  name: "Task.of(Err)",
+  group: "Micro::Async::Construction",
+  fn: () => {
+    const res = Task.of(ERR);
+  },
+});
+
+Deno.bench({
+  name: "Task.of(Promise<Result>)",
+  group: "Micro::Async::Construction",
+  fn: () => {
+    const res = Task.of(produceRes());
+  },
+});
+
+Deno.bench({
+  name: "Task.fromFallible(() => Promise<string>)",
+  group: "Micro::Async::Construction",
+  fn: () => {
+    const res = Task.fromFallible(produceValue, asInfallible);
+  },
+});
+
+Deno.bench({
+  name: "AsyncFn() => Promise<Result>)",
+  group: "Micro::Async::Construction",
+  fn: () => {
+    const res = produceRes();
   },
 });
 
 Deno.bench({
   name: "Ok",
-  group: "Micro::Instantiation",
+  group: "Micro::Construction",
   fn: () => {
     const res = Ok("foo");
   },
@@ -45,7 +114,7 @@ Deno.bench({
 
 Deno.bench({
   name: "Err",
-  group: "Micro::Instantiation",
+  group: "Micro::Construction",
   fn: () => {
     const res = Err("foo");
   },
@@ -53,7 +122,7 @@ Deno.bench({
 
 Deno.bench({
   name: "Option",
-  group: "Micro::Instantiation",
+  group: "Micro::Construction",
   fn: () => {
     const res = Option("foo");
   },

--- a/lib/async/task.ts
+++ b/lib/async/task.ts
@@ -513,7 +513,7 @@ export class Task<T, E> extends Promise<Result<T, E>> {
    * import { Task } from "./task.ts";
    *
    * const err = Result(Error()) as Result<number, Error>;
-   * const task = Task.of(ok);
+   * const task = Task.of(err);
    *
    * const union: number | string = await task.unwrapOr(Promise.resolve("foo"));
    *
@@ -537,7 +537,7 @@ export class Task<T, E> extends Promise<Result<T, E>> {
    * import { Task } from "./task.ts";
    *
    * const err = Result(Error("foo")) as Result<number, Error>;
-   * const task = Task.of(ok);
+   * const task = Task.of(err);
    *
    * const union: number | string = await task.unwrapOrElse(
    *   async (err) => err.message

--- a/lib/async/task.ts
+++ b/lib/async/task.ts
@@ -75,7 +75,10 @@ export class Task<T, E> extends Promise<Result<T, E>> {
   static of<T, E>(
     value: Result<T, E> | PromiseLike<Result<T, E>>,
   ): Task<T, E> {
-    return Task.from(() => value);
+    const p = new Promise<Result<T, E>>((resolve) => resolve(value)).catch(
+      asInfallible,
+    );
+    return new Task<T, E>((resolve) => resolve(p));
   }
 
   /**

--- a/lib/async/task.ts
+++ b/lib/async/task.ts
@@ -240,7 +240,7 @@ export class Task<T, E> extends Promise<Result<T, E>> {
     errorMapFn: (reason: unknown) => E,
   ): Task<T, E> {
     const p = new Promise<T>((resolve) => resolve(fn()))
-      .then((v) => Ok(v), (e) => Err(errorMapFn(e)))
+      .then((v) => Ok(v), (e) => Err(errorMapFn(e)));
 
     return new Task<T, E>((resolve) => resolve(p));
   }
@@ -526,7 +526,7 @@ export class Task<T, E> extends Promise<Result<T, E>> {
 
   /**
    * Same as {@linkcode Task#unwrap} but returns a fallback value, which can based
-   * constructed from the underlying value of type `<E>` in case of `Err<E>` 
+   * constructed from the underlying value of type `<E>` in case of `Err<E>`
    *
    * @category Task::Basic
    *

--- a/lib/async/task_test.ts
+++ b/lib/async/task_test.ts
@@ -24,7 +24,7 @@ Deno.test("eitherway::Task", async (t) => {
 
         const task = Task.of(promiseRes);
 
-        task.catch((e) => assertStrictEquals(e?.cause, te));
+        task.catch((e) => assertStrictEquals(e, te));
       },
     );
 
@@ -521,6 +521,38 @@ Deno.test("eitherway::Task", async (t) => {
 
         assertStrictEquals(ok.isOk(), true);
         assertStrictEquals(ok.unwrap(), 42);
+      });
+    });
+
+    await t.step("Task<T, E> -> Unwrap Methods", async (t) => {
+      await t.step(".unwrap() -> returns the wrapped value", async () => {
+        const task: Task<number, TypeError> = Task.succeed(42);
+
+        const unwrapped = task.unwrap();
+        const value = await unwrapped;
+
+        assertType<IsExact<typeof unwrapped, Promise<number | TypeError>>>(true);
+        assertStrictEquals(value, 42);
+      });
+
+      await t.step(".unwrapOr() -> returns the fallback value in case of Err<E>", async () => {
+        const task: Task<number, TypeError> = Task.fail(TypeError());
+
+        const unwrapped = task.unwrapOr("foo");
+        const value = await unwrapped;
+
+        assertType<IsExact<typeof unwrapped, Promise<number | string>>>(true);
+        assertStrictEquals(value, "foo");
+      });
+
+      await t.step(".unwrapOrElse() -> returns the constructed fallback value in case of Err<E>", async () => {
+        const task: Task<number, TypeError> = Task.fail(TypeError("foo"));
+
+        const unwrapped = task.unwrapOrElse(async (err) => err.message);
+        const value = await unwrapped;
+
+        assertType<IsExact<typeof unwrapped, Promise<number | string>>>(true);
+        assertStrictEquals(value, "foo");
       });
     });
 

--- a/lib/async/task_test.ts
+++ b/lib/async/task_test.ts
@@ -531,29 +531,37 @@ Deno.test("eitherway::Task", async (t) => {
         const unwrapped = task.unwrap();
         const value = await unwrapped;
 
-        assertType<IsExact<typeof unwrapped, Promise<number | TypeError>>>(true);
+        assertType<IsExact<typeof unwrapped, Promise<number | TypeError>>>(
+          true,
+        );
         assertStrictEquals(value, 42);
       });
 
-      await t.step(".unwrapOr() -> returns the fallback value in case of Err<E>", async () => {
-        const task: Task<number, TypeError> = Task.fail(TypeError());
+      await t.step(
+        ".unwrapOr() -> returns the fallback value in case of Err<E>",
+        async () => {
+          const task: Task<number, TypeError> = Task.fail(TypeError());
 
-        const unwrapped = task.unwrapOr("foo");
-        const value = await unwrapped;
+          const unwrapped = task.unwrapOr("foo");
+          const value = await unwrapped;
 
-        assertType<IsExact<typeof unwrapped, Promise<number | string>>>(true);
-        assertStrictEquals(value, "foo");
-      });
+          assertType<IsExact<typeof unwrapped, Promise<number | string>>>(true);
+          assertStrictEquals(value, "foo");
+        },
+      );
 
-      await t.step(".unwrapOrElse() -> returns the constructed fallback value in case of Err<E>", async () => {
-        const task: Task<number, TypeError> = Task.fail(TypeError("foo"));
+      await t.step(
+        ".unwrapOrElse() -> returns the constructed fallback value in case of Err<E>",
+        async () => {
+          const task: Task<number, TypeError> = Task.fail(TypeError("foo"));
 
-        const unwrapped = task.unwrapOrElse(async (err) => err.message);
-        const value = await unwrapped;
+          const unwrapped = task.unwrapOrElse(async (err) => err.message);
+          const value = await unwrapped;
 
-        assertType<IsExact<typeof unwrapped, Promise<number | string>>>(true);
-        assertStrictEquals(value, "foo");
-      });
+          assertType<IsExact<typeof unwrapped, Promise<number | string>>>(true);
+          assertStrictEquals(value, "foo");
+        },
+      );
     });
 
     await t.step("Task<T, E> -> Transformation Methods", async (t) => {


### PR DESCRIPTION
- perf(task): removed one layer of indirection from  constructor
- test(async): added tests and docs for unwrap methods
- perf(async): added more comparissons to async construction bench and added timeout to async propagation benchmark suite
- chore(async): fmt'ed changes
